### PR TITLE
   Fix inference output error by forcing the GTiff driver

### DIFF
--- a/Trailscan/inference.py
+++ b/Trailscan/inference.py
@@ -390,7 +390,8 @@ class TrailscanInferenceProcessingAlgorithm(QgsProcessingAlgorithm):
 
         meta.update({
             'count': 1,
-            'dtype': 'float32'
+            'dtype': 'float32',
+            'driver': 'GTiff'  # force a writable GeoTIFF driver (input may use the read-only LIBERTIFF driver)
         })
 
         with rasterio.open(output_raster, 'w', **meta) as dst:


### PR DESCRIPTION
   Recent GDAL versions may open the input raster with the read-only
   LIBERTIFF driver. The driver name was inherited into the output
   metadata, causing a DriverCapabilityError on write. Explicitly set
   driver='GTiff' so the Trailmap can always be written.

   Fixes #24