### PR TITLE
Make plugin compatible with QGIS 4.0 / Qt6

### DIFF
--- a/Trailscan/__init__.py
+++ b/Trailscan/__init__.py
@@ -10,7 +10,7 @@
 
 #---------------------------------------------------------------------
 from qgis.PyQt.QtGui import QIcon
-from qgis.PyQt.QtWidgets import QAction, QMessageBox
+from qgis.PyQt.QtWidgets import QMessageBox
 from qgis.core import QgsApplication, QgsProcessingProvider, Qgis
 import processing
 import os

--- a/Trailscan/metadata.txt
+++ b/Trailscan/metadata.txt
@@ -1,6 +1,7 @@
 [general]
 name=TrailScan
 qgisMinimumVersion=3.38
+qgisMaximumVersion=4.99
 description=Deep learning-based segmentation of skid trails from airborne LiDAR data
 about=Note: On first installation TrailScan downloads additional Python packages (rasterio, laspy, scipy and others). This can take several minutes, during which QGIS may become unresponsive - please save your work before installing and wait until the installation has finished. TrailScan is a QGIS plugin for automatic mapping of skid trails from Airborne Laser Scanning (ALS) data in forest environments. Input: ALS point clouds (.las / .laz) from aircraft, helicopters, or UAVs. Workflow: 1. Preprocessing – Convert the point cloud into a normalized multi-band raster (DTM, CHM, MRM, VDI). 2. Inference – Apply the pretrained TrailScan deep learning model to generate a probability map ("Trailmap"). The trained TrailScan model is available at https://doi.org/10.25625/GEIP6T. Output: A georeferenced raster ("Trailmap" with values 0–1) indicating the likelihood of skid trail presence, ready for further GIS analysis.
 version=0.1.2

--- a/Trailscan/packages_installer_dialog.py
+++ b/Trailscan/packages_installer_dialog.py
@@ -197,7 +197,7 @@ class PackagesInstallerDialog(QDialog, FORM_CLASS):
         """ Move the window to the top.
         Although if installed from plugin manager, the plugin manager will move itself to the top anyway.
         """
-        self.setWindowState((self.windowState() & ~QtCore.Qt.WindowMinimized) | QtCore.Qt.WindowActive)
+        self.setWindowState((self.windowState() & ~QtCore.Qt.WindowState.WindowMinimized) | QtCore.Qt.WindowState.WindowActive)
 
         if sys.platform == "linux" or sys.platform == "linux2":
             pass
@@ -621,7 +621,7 @@ def check_required_packages_and_install_if_necessary(iface):
         # If still not available, show installer dialog
         global dialog
         dialog = PackagesInstallerDialog(iface)
-        dialog.setWindowModality(QtCore.Qt.WindowModal)
+        dialog.setWindowModality(QtCore.Qt.WindowModality.WindowModal)
         dialog.show()
         dialog.move_to_top()
         

--- a/Trailscan/trailscan.py
+++ b/Trailscan/trailscan.py
@@ -11,8 +11,7 @@
 
 import os
 from qgis.PyQt.QtCore import Qt
-from qgis.PyQt.QtGui import QIcon
-from qgis.PyQt.QtWidgets import QAction
+from qgis.PyQt.QtGui import QIcon, QAction
 from qgis.core import QgsApplication, QgsProcessingProvider, QgsProcessingAlgorithm, Qgis
 import processing
 
@@ -51,7 +50,7 @@ class TrailScan:
         self.action2.setStatusTip('Run TrailScan model inference on preprocessed raster')
 
         # Show text next to icon
-        self.toolbar.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
+        self.toolbar.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextBesideIcon)
 
         # Add actions to toolbar
         self.toolbar.addAction(self.action)
@@ -72,7 +71,7 @@ class TrailScan:
             self.algorithms_loaded = True
         except Exception as e:
             QgsApplication.messageLog().logMessage(f"Failed to initialize TrailScan processing provider: {e}",
-                                                   "TrailScan", Qgis.Critical)
+                                                   "TrailScan", Qgis.MessageLevel.Critical)
             self.algorithms_loaded = False
 
     def unload(self):
@@ -93,7 +92,7 @@ class TrailScan:
         try:
             processing.execAlgorithmDialog("trailscan:preprocessing")
         except Exception as e:
-            QgsApplication.messageLog().logMessage(f"Failed to run preprocessing: {e}", "TrailScan", Qgis.Critical)
+            QgsApplication.messageLog().logMessage(f"Failed to run preprocessing: {e}", "TrailScan", Qgis.MessageLevel.Critical)
             self.iface.messageBar().pushCritical("TrailScan Plugin", f"Failed to run preprocessing: {e}")
 
     def runInference(self):
@@ -105,7 +104,7 @@ class TrailScan:
         try:
             processing.execAlgorithmDialog("trailscan:inference")
         except Exception as e:
-            QgsApplication.messageLog().logMessage(f"Failed to run inference: {e}", "TrailScan", Qgis.Critical)
+            QgsApplication.messageLog().logMessage(f"Failed to run inference: {e}", "TrailScan", Qgis.MessageLevel.Critical)
             self.iface.messageBar().pushCritical("TrailScan Plugin", f"Failed to run inference: {e}")
 
 # --------------------------------------------------------------------
@@ -147,7 +146,7 @@ class TrailScanProvider(QgsProcessingProvider):
             QgsApplication.messageLog().logMessage(
                 f"TrailScan: Algorithms not registered yet - missing dependency ({e}). "
                 f"Please restart QGIS once package installation has finished.",
-                "TrailScan", Qgis.Warning)
+                "TrailScan", Qgis.MessageLevel.Warning)
             return
 
         self.addAlgorithm(TrailscanPreProcessingAlgorithm())
@@ -228,4 +227,4 @@ class TrailscanInferenceProcessingAlgorithm(QgsProcessingAlgorithm):
         )
 
     def createInstance(self):
-        return self._
+        return self.__class__()


### PR DESCRIPTION
   - metadata.txt: add qgisMaximumVersion=4.99 so QGIS 4 loads the plugin
   - Fully qualify Qt enums (Qt.ToolButtonStyle, Qt.WindowState, Qt.WindowModality) - works in both PyQt5 and PyQt6
   - Fully qualify QGIS enums (Qgis.MessageLevel.Critical/Warning)
   - Import QAction from qgis.PyQt.QtGui (moved there in Qt6)
   - Restore the end of trailscan.py, which had been truncated in an earlier commit

   Fixes #29